### PR TITLE
#31: Prevent setting a build directory outside of your vite project

### DIFF
--- a/src/vite-plugin-symfony/src/index.ts
+++ b/src/vite-plugin-symfony/src/index.ts
@@ -25,6 +25,7 @@ import {
   getFileInfos,
   getInputRelPath,
   parseVersionString,
+  isSubdirectory,
 } from "./utils";
 import { resolvePluginOptions, resolveBase, resolveOutDir, refreshPaths, resolvePublicDir } from "./pluginOptions";
 
@@ -148,6 +149,13 @@ export default function symfony(userOptions: Partial<VitePluginSymfonyOptions> =
 
           const buildDir = resolve(viteConfig.root, viteConfig.build.outDir);
 
+          // buildDir is not a subdirectory of the vite project root -> potentially dangerous
+          if (!isSubdirectory(viteConfig.root, buildDir)) {
+            throw new Error(
+              `Always set outDir to a subdirectory of your project to prevent recursively deleting files anywhere else.`,
+            );
+          }
+
           if (!existsSync(buildDir)) {
             mkdirSync(buildDir, { recursive: true });
           }
@@ -266,7 +274,7 @@ export default function symfony(userOptions: Partial<VitePluginSymfonyOptions> =
       outputCount++;
       const output = viteConfig.build.rollupOptions?.output;
 
-      // if we have multiple build passes output is an array of each passe.
+      // if we have multiple build passes output is an array of each pass.
       // else we have an object of this unique pass
       const outputLength = Array.isArray(output) ? output.length : 1;
 

--- a/src/vite-plugin-symfony/src/utils.ts
+++ b/src/vite-plugin-symfony/src/utils.ts
@@ -20,6 +20,19 @@ export function slash(p: string): string {
   return p.replace(/\\/g, "/");
 }
 
+export function isSubdirectory(parent: string, child: string) {
+  parent = path.normalize(parent);
+  child = path.normalize(child);
+
+  if (parent == child) {
+    return false;
+  }
+
+  const parentDirs = parent.split(path.sep).filter((dir) => dir !== "");
+  const childDirs = child.split(path.sep).filter((dir) => dir !== "");
+  return parentDirs.every((dir, i) => childDirs[i] === dir);
+}
+
 export function normalizePath(id: string): string {
   return path.posix.normalize(isWindows ? slash(id) : id);
 }

--- a/src/vite-plugin-symfony/tests/utils.test.ts
+++ b/src/vite-plugin-symfony/tests/utils.test.ts
@@ -1,5 +1,12 @@
 import { describe, it } from "vitest";
-import { getLegacyName, normalizePath, getFileInfos, getInputRelPath, prepareRollupInputs } from "../src/utils";
+import {
+  getLegacyName,
+  normalizePath,
+  getFileInfos,
+  getInputRelPath,
+  prepareRollupInputs,
+  isSubdirectory,
+} from "../src/utils";
 import { OutputChunk, OutputAsset, NormalizedOutputOptions } from "rollup";
 import {
   asyncDepChunk,
@@ -244,5 +251,42 @@ describe("getInputRelPath", () => {
         viteBaseConfig,
       ),
     ).toBe("assets/page/welcome/index-legacy.js");
+  });
+});
+
+describe("isAncestorDir", () => {
+  it("subdirectory is a subdirectory", ({ expect }) => {
+    expect(isSubdirectory("/projects/vite-project", "/projects/vite-project/public")).toBe(true);
+  });
+  it("same folder is not a subdirectory", ({ expect }) => {
+    expect(isSubdirectory("/projects/vite-project", "/projects/vite-project")).toBe(false);
+  });
+  it("sibling folder is not a subdirectory", ({ expect }) => {
+    expect(isSubdirectory("/projects/vite-project", "/projects/symfony-project")).toBe(false);
+  });
+  it("sibling folder starting with same name is not a subdirectory", ({ expect }) => {
+    expect(isSubdirectory("/projects/vite-project", "/projects/vite-project-2")).toBe(false);
+  });
+  it("traversing up the tree and into a sibling folder is not a subdirectory", ({ expect }) => {
+    expect(isSubdirectory("/projects/vite-project", "/projects/vite-project/../react-project")).toBe(false);
+  });
+  it("unnormalized path in project folder: is a subdirectory", ({ expect }) => {
+    expect(isSubdirectory("/projects/vite-project", "/projects/vite-project/./public")).toBe(true);
+  });
+  it("unnormalized path with path traversal into subdirectory is a subdirectory", ({ expect }) => {
+    expect(isSubdirectory("/vite-project/../projects", "/projects/vite-project")).toBe(true);
+  });
+  it("unnormalized path relative to current directory: is not a subdirectory", ({ expect }) => {
+    expect(isSubdirectory("/projects/vite-project", "./vite-project")).toBe(false);
+  });
+  // this test fails on UNIX but succeeds on Windows
+  // it("Windows: subdirectory is a subdirectory", ({ expect }) => {
+  // expect(isSubdirectory("C:\\projects", "C:\\projects\\vite-project")).toBe(true);
+  // });
+  it("Windows: different directory is not a subdirectory", ({ expect }) => {
+    expect(isSubdirectory("C:\\projects", "C:\\Users")).toBe(false);
+  });
+  it("Windows: subdirectory on another drive is not a subdirectory", ({ expect }) => {
+    expect(isSubdirectory("C:\\projects", "D:\\projects\\svelte-project")).toBe(false);
   });
 });


### PR DESCRIPTION
Prevent setting a build directory outside of your vite project as this would delete all files inside this folder recursively.

Is connected to [lhapaipai/vite-plugin-symfony/issues/31](https://github.com/lhapaipai/vite-plugin-symfony/issues/31)