### PR TITLE
Change dependency to the non-internal ServiceLocator class

### DIFF
--- a/src/vite-bundle/src/Service/EntrypointsLookupCollection.php
+++ b/src/vite-bundle/src/Service/EntrypointsLookupCollection.php
@@ -3,7 +3,7 @@
 namespace Pentatrion\ViteBundle\Service;
 
 use Pentatrion\ViteBundle\Exception\UndefinedConfigNameException;
-use Symfony\Component\DependencyInjection\Argument\ServiceLocator;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 
 class EntrypointsLookupCollection
 {

--- a/src/vite-bundle/src/Service/TagRendererCollection.php
+++ b/src/vite-bundle/src/Service/TagRendererCollection.php
@@ -3,7 +3,7 @@
 namespace Pentatrion\ViteBundle\Service;
 
 use Pentatrion\ViteBundle\Exception\UndefinedConfigNameException;
-use Symfony\Component\DependencyInjection\Argument\ServiceLocator;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 
 class TagRendererCollection
 {


### PR DESCRIPTION
In a project with the bundle installed, `bin/console lint:container` would fail because of a dependency on an internal Symfony class:

```
> bin/console lint:container
                                                                                                                        
 [ERROR] Invalid definition for service "twig": argument 1 of                                                           
         "Pentatrion\ViteBundle\Service\TagRendererCollection::__construct()" accepts                                   
         "Symfony\Component\DependencyInjection\Argument\ServiceLocator",                                               
         "Symfony\Component\DependencyInjection\ServiceLocator" passed.                                                 
```

Change this dependency to the public ServiceLocator to fix this error.