### PR TITLE
Remove useless export

### DIFF
--- a/src/vite-plugin-symfony/src/stimulus/helpers/index.ts
+++ b/src/vite-plugin-symfony/src/stimulus/helpers/index.ts
@@ -1,4 +1,1 @@
 export { startStimulusApp, registerControllers } from "./base";
-export { registerVueControllerComponents } from "./vue";
-export { registerReactControllerComponents } from "./react/index";
-export { registerSvelteControllerComponents } from "./svelte/index";


### PR DESCRIPTION
Those elements are already exported in their respective folders, so there's no need to have them there. This caused the same bug with the "vue" import error in the previous [issue](https://github.com/lhapaipai/vite-plugin-symfony/issues/35).