### PR TITLE
Use Request::getUriForPath to build absolute URLs

### DIFF
--- a/src/vite-bundle/src/Asset/ViteAssetVersionStrategy.php
+++ b/src/vite-bundle/src/Asset/ViteAssetVersionStrategy.php
@@ -5,7 +5,7 @@ namespace Pentatrion\ViteBundle\Asset;
 use Pentatrion\ViteBundle\Service\FileAccessor;
 use Symfony\Component\Asset\Exception\AssetNotFoundException;
 use Symfony\Component\Asset\VersionStrategy\VersionStrategyInterface;
-use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class ViteAssetVersionStrategy implements VersionStrategyInterface
 {
@@ -13,7 +13,7 @@ class ViteAssetVersionStrategy implements VersionStrategyInterface
     private array $configs;
     private string $configName;
     private $useAbsoluteUrl;
-    private ?RouterInterface $router;
+    private ?RequestStack $requestStack;
     private bool $strictMode;
 
     private ?string $viteMode = null;
@@ -26,14 +26,14 @@ class ViteAssetVersionStrategy implements VersionStrategyInterface
         array $configs,
         string $defaultConfigName,
         bool $useAbsoluteUrl,
-        RouterInterface $router = null,
+        RequestStack $requestStack = null,
         bool $strictMode = true
     ) {
         $this->fileAccessor = $fileAccessor;
         $this->configs = $configs;
         $this->configName = $defaultConfigName;
         $this->useAbsoluteUrl = $useAbsoluteUrl;
-        $this->router = $router;
+        $this->requestStack = $requestStack;
         $this->strictMode = $strictMode;
 
         $this->setConfig($this->configName);
@@ -64,11 +64,11 @@ class ViteAssetVersionStrategy implements VersionStrategyInterface
 
     private function completeURL(string $path): string
     {
-        if (0 === strpos($path, 'http') || false === $this->useAbsoluteUrl || null === $this->router) {
+        if (0 === strpos($path, 'http') || false === $this->useAbsoluteUrl || null === $this->requestStack || null === $this->requestStack->getCurrentRequest()) {
             return $path;
         }
 
-        return $this->router->getContext()->getScheme().'://'.$this->router->getContext()->getHost().$path;
+        return $this->requestStack->getCurrentRequest()->getUriForPath($path);
     }
 
     private function getassetsPath(string $path): ?string

--- a/src/vite-bundle/src/Resources/config/services.yaml
+++ b/src/vite-bundle/src/Resources/config/services.yaml
@@ -14,7 +14,7 @@ services:
             - "@pentatrion_vite.tag_renderer_collection"
             - "%pentatrion_vite.absolute_url%"
             - "%pentatrion_vite.preload%"
-            - "@?router"
+            - "@?request_stack"
             - "@?event_dispatcher"
 
     Pentatrion\ViteBundle\Service\EntrypointRenderer:
@@ -47,7 +47,7 @@ services:
             - "%pentatrion_vite.configs%"
             - "%pentatrion_vite.default_config%"
             - "%pentatrion_vite.absolute_url%"
-            - "@?router"
+            - "@?request_stack"
             - true
 
 

--- a/src/vite-bundle/src/Service/EntrypointRenderer.php
+++ b/src/vite-bundle/src/Service/EntrypointRenderer.php
@@ -5,7 +5,7 @@ namespace Pentatrion\ViteBundle\Service;
 use Pentatrion\ViteBundle\Event\RenderAssetTagEvent;
 use Pentatrion\ViteBundle\Model\Tag;
 use Pentatrion\ViteBundle\Util\InlineContent;
-use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Service\ResetInterface;
 
@@ -15,7 +15,7 @@ class EntrypointRenderer implements ResetInterface
     private TagRendererCollection $tagRendererCollection;
     private bool $useAbsoluteUrl;
     private string $preload;
-    private ?RouterInterface $router;
+    private ?RequestStack $requestStack;
     private ?EventDispatcherInterface $eventDispatcher;
 
     private $returnedViteClients = [];
@@ -32,14 +32,14 @@ class EntrypointRenderer implements ResetInterface
         TagRendererCollection $tagRendererCollection,
         bool $useAbsoluteUrl = false,
         string $preload = 'link-tag',
-        RouterInterface $router = null,
+        RequestStack $requestStack = null,
         EventDispatcherInterface $eventDispatcher = null
     ) {
         $this->entrypointsLookupCollection = $entrypointsLookupCollection;
         $this->tagRendererCollection = $tagRendererCollection;
         $this->useAbsoluteUrl = $useAbsoluteUrl;
         $this->preload = $preload;
-        $this->router = $router;
+        $this->requestStack = $requestStack;
         $this->eventDispatcher = $eventDispatcher;
     }
 
@@ -55,11 +55,11 @@ class EntrypointRenderer implements ResetInterface
 
     private function completeURL(string $path, bool $useAbsoluteUrl = false): string
     {
-        if (0 === strpos($path, 'http') || false === $useAbsoluteUrl || null === $this->router) {
+        if (0 === strpos($path, 'http') || false === $useAbsoluteUrl || null === $this->requestStack || null === $this->requestStack->getCurrentRequest()) {
             return $path;
         }
 
-        return $this->router->getContext()->getScheme().'://'.$this->router->getContext()->getHost().$path;
+        return $this->requestStack->getCurrentRequest()->getUriForPath($path);
     }
 
     private function shouldUseAbsoluteURL(array $options, string $configName = null): bool

--- a/src/vite-bundle/tests/Service/EntrypointRendererTest.php
+++ b/src/vite-bundle/tests/Service/EntrypointRendererTest.php
@@ -12,6 +12,8 @@ use Pentatrion\ViteBundle\Service\TagRendererCollection;
 use Pentatrion\ViteBundle\Event\RenderAssetTagEvent;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -322,23 +324,24 @@ class EntrypointRendererTest extends TestCase
     public function testRenderWithAbsoluteUrl()
     {
         /**
-         * @var Stub|RequestContext $context
+         * @var Stub|Request $requestStack
          */
-        $context = $this->createStub(RequestContext::class);
-        $context
-            ->method('getScheme')
-            ->willReturn('http');
+        $request = $this->createStub(Request::class);
 
-        $context
-            ->method('getHost')
-            ->willReturn('mydomain.local');
+        $request
+            ->method('getUriForPath')
+            ->willReturnCallback(function ($path) {
+                return 'http://mydomain.local' . $path;
+            })
+        ;
+
         /**
-         * @var Stub|RouterInterface $router
+         * @var Stub|RequestStack $requestStack
          */
-        $router = $this->createStub(RouterInterface::class);
-        $router
-            ->method('getContext')
-            ->willReturn($context);
+        $requestStack = $this->createStub(RequestStack::class);
+        $requestStack
+            ->method('getCurrentRequest')
+            ->willReturn($request);
 
         $entrypointsLookupBasicBuild = $this->getEntrypointsLookup('basic-build');
         $entrypointsLookupBasicDev = $this->getEntrypointsLookup('basic-dev');
@@ -348,7 +351,7 @@ class EntrypointRendererTest extends TestCase
             $this->getBasicTagRendererCollection(),
             true,
             'link-tag',
-            $router,
+            $requestStack,
             null,
         );
         $this->assertEquals(
@@ -362,7 +365,7 @@ class EntrypointRendererTest extends TestCase
             $this->getBasicTagRendererCollection(),
             false,
             'link-tag',
-            $router,
+            $requestStack,
             null,
         );
         $this->assertEquals(
@@ -376,7 +379,7 @@ class EntrypointRendererTest extends TestCase
             $this->getBasicTagRendererCollection(),
             true,
             'link-tag',
-            $router,
+            $requestStack,
             null,
         );
         $this->assertEquals(


### PR DESCRIPTION
I noticed whilst looking into the issue discussed in #7 that the method to generate absolute URLs for assets when `absolute_url` is `true` was missing a few potential components in in the URL (port, base path etc).

For example, if a site was hosted at `http://example.org:8080/subdirectory` and we wanted to get an absolute URL for `/build/foo.jpg`, the current methods return:

```
http://example.org/build/foo.jpg
```

Which would result in a 404.

This PR updates the completeURL methods in `ViteAssetVersionStrategy` and `EntrypointRenderer` so that they use the `getUriForPath` method from Symfony's Request object. This builds the full URL including all required components and in the example above returns the following correct URL:

```
http://example.org:8080/subdirectory/build/foo.jpg
```