### PR TITLE
Formatting fix in vite printUrls output

### DIFF
--- a/src/vite-plugin-symfony/src/entrypoints/index.ts
+++ b/src/vite-plugin-symfony/src/entrypoints/index.ts
@@ -129,7 +129,7 @@ export default function symfonyEntrypoints(pluginOptions: VitePluginSymfonyEntry
           versions.push(colors.dim(`pentatrion/vite-bundle: `) + colors.bold(`v${bundleVersion[0]}`));
         }
         const versionStr = versions.length === 0 ? "" : versions.join(colors.dim(", "));
-        console.log(`  ${colors.green("➜")}  Vite ${colors.yellow("⚡️")}Symfony: ${versionStr}`);
+        console.log(`  ${colors.green("➜")}  Vite ${colors.yellow("⚡️")} Symfony: ${versionStr}`);
       };
 
       devServer.httpServer?.once("listening", () => {

--- a/src/vite-plugin-symfony/src/entrypoints/index.ts
+++ b/src/vite-plugin-symfony/src/entrypoints/index.ts
@@ -126,7 +126,7 @@ export default function symfonyEntrypoints(pluginOptions: VitePluginSymfonyEntry
           versions.push(colors.dim(`vite-plugin-symfony: `) + colors.bold(`v${pluginVersion[0]}`));
         }
         if (bundleVersion[0]) {
-          versions.push(colors.dim(`pentatrion/vite-bundle: `) + colors.bold(`v${bundleVersion[0]}`));
+          versions.push(colors.dim(`pentatrion/vite-bundle: `) + colors.bold(`${bundleVersion[0]}`));
         }
         const versionStr = versions.length === 0 ? "" : versions.join(colors.dim(", "));
         console.log(`  ${colors.green("➜")}  Vite ${colors.yellow("⚡️")} Symfony: ${versionStr}`);


### PR DESCRIPTION
This PR contains a couple of small formatting fixes in the print URLs output when Vite starts.

I added a space between the bolt emoji and 'Symfony', and removed the extra v when outputting the vite-bundle version (version obtained from composer.lock is already prefixed with v)

Before:

> Vite ⚡️Symfony: vite-plugin-symfony: v6.3.2, pentatrion/vite-bundle: vv6.3.3

After:

> Vite ⚡️ Symfony: vite-plugin-symfony: v6.3.2, pentatrion/vite-bundle: v6.3.3