### PR TITLE
Add crossorigin attribute to Link header for scripts with type=module

### DIFF
--- a/src/vite-bundle/src/DependencyInjection/PentatrionViteExtension.php
+++ b/src/vite-bundle/src/DependencyInjection/PentatrionViteExtension.php
@@ -43,6 +43,7 @@ class PentatrionViteExtension extends Extension
         $container->setParameter('pentatrion_vite.absolute_url', $bundleConfig['absolute_url']);
         $container->setParameter('pentatrion_vite.proxy_origin', $bundleConfig['proxy_origin']);
         $container->setParameter('pentatrion_vite.throw_on_missing_entry', $bundleConfig['throw_on_missing_entry']);
+        $container->setParameter('pentatrion_vite.crossorigin', $bundleConfig['crossorigin']);
 
         if (
             count($bundleConfig['configs']) > 0) {

--- a/src/vite-bundle/src/EventListener/PreloadAssetsEventListener.php
+++ b/src/vite-bundle/src/EventListener/PreloadAssetsEventListener.php
@@ -35,8 +35,12 @@ class PreloadAssetsEventListener implements EventSubscriberInterface
         /** @var GenericLinkProvider $linkProvider */
         $linkProvider = $request->attributes->get('_links');
 
-        foreach ($this->entrypointRenderer->getRenderedScripts() as $href) {
+        foreach ($this->entrypointRenderer->getRenderedScripts() as $href => $tag) {
             $link = $this->createLink('preload', $href)->withAttribute('as', 'script');
+
+            if ('module' === $tag->getAttribute('type')) {
+                $link = $link->withAttribute('crossorigin', true);
+            }
 
             $linkProvider = $linkProvider->withLink($link);
         }

--- a/src/vite-bundle/src/EventListener/PreloadAssetsEventListener.php
+++ b/src/vite-bundle/src/EventListener/PreloadAssetsEventListener.php
@@ -11,10 +11,12 @@ use Symfony\Component\WebLink\Link;
 class PreloadAssetsEventListener implements EventSubscriberInterface
 {
     private EntrypointRenderer $entrypointRenderer;
+    private string|bool $crossOriginAttribute;
 
-    public function __construct(EntrypointRenderer $entrypointRenderer)
+    public function __construct(EntrypointRenderer $entrypointRenderer, string|bool $crossOriginAttribute)
     {
         $this->entrypointRenderer = $entrypointRenderer;
+        $this->crossOriginAttribute = $crossOriginAttribute;
     }
 
     public function onKernelResponse(ResponseEvent $event): void
@@ -39,7 +41,7 @@ class PreloadAssetsEventListener implements EventSubscriberInterface
             $link = $this->createLink('preload', $href)->withAttribute('as', 'script');
 
             if ('module' === $tag->getAttribute('type')) {
-                $link = $link->withAttribute('crossorigin', true);
+                $link = $link->withAttribute('crossorigin', $this->crossOriginAttribute ?: 'anonymous');
             }
 
             $linkProvider = $linkProvider->withLink($link);

--- a/src/vite-bundle/src/Resources/config/services.yaml
+++ b/src/vite-bundle/src/Resources/config/services.yaml
@@ -56,6 +56,7 @@ services:
         tags: ["kernel.event_subscriber"]
         arguments:
             - "@pentatrion_vite.entrypoint_renderer"
+            - "%pentatrion_vite.crossorigin%"
 
     pentatrion_vite.file_accessor:
         class: Pentatrion\ViteBundle\Service\FileAccessor

--- a/src/vite-bundle/src/Service/EntrypointRenderer.php
+++ b/src/vite-bundle/src/Service/EntrypointRenderer.php
@@ -91,6 +91,9 @@ class EntrypointRenderer implements ResetInterface
         ];
     }
 
+    /**
+     * @return array<string, Tag>
+     */
     public function getRenderedScripts(): array
     {
         return $this->renderedFiles['scripts'];
@@ -166,8 +169,8 @@ class EntrypointRenderer implements ResetInterface
 
         /* normal js scripts */
         foreach ($entrypointsLookup->getJSFiles($entryName) as $filePath) {
-            if (false === \in_array($filePath, $this->renderedFiles['scripts'], true)) {
-                $tags[] = $tagRenderer->createScriptTag(
+            if (!isset($this->renderedFiles['scripts'][$filePath])) {
+                $tag = $tagRenderer->createScriptTag(
                     array_merge(
                         [
                             'type' => 'module',
@@ -178,7 +181,9 @@ class EntrypointRenderer implements ResetInterface
                     )
                 );
 
-                $this->renderedFiles['scripts'][] = $filePath;
+                $tags[] = $tag;
+
+                $this->renderedFiles['scripts'][$filePath] = $tag;
             }
         }
 
@@ -187,8 +192,8 @@ class EntrypointRenderer implements ResetInterface
             $id = self::pascalToKebab("vite-legacy-entry-$entryName");
 
             $filePath = $entrypointsLookup->getLegacyJSFile($entryName);
-            if (false === \in_array($filePath, $this->renderedFiles['scripts'], true)) {
-                $tags[] = $tagRenderer->createScriptTag(
+            if (!isset($this->renderedFiles['scripts'][$filePath])) {
+                $tag = $tagRenderer->createScriptTag(
                     [
                         'nomodule' => true,
                         'data-src' => $this->completeURL($filePath, $useAbsoluteUrl),
@@ -200,7 +205,9 @@ class EntrypointRenderer implements ResetInterface
                     InlineContent::getSystemJSInlineCode($id)
                 );
 
-                $this->renderedFiles['scripts'][] = $filePath;
+                $tags[] = $tag;
+
+                $this->renderedFiles['scripts'][$filePath] = $tag;
             }
         }
 
@@ -240,24 +247,30 @@ class EntrypointRenderer implements ResetInterface
 
         if ($isBuild) {
             foreach ($entrypointsLookup->getJavascriptDependencies($entryName) as $filePath) {
-                if (false === \in_array($filePath, $this->renderedFiles['scripts'], true)) {
-                    $tags[] = $tagRenderer->createModulePreloadLinkTag(
+                if (!isset($this->renderedFiles['scripts'][$filePath])) {
+                    $tag = $tagRenderer->createModulePreloadLinkTag(
                         $this->completeURL($filePath, $useAbsoluteUrl),
                         ['integrity' => $entrypointsLookup->getFileHash($filePath)]
                     );
-                    $this->renderedFiles['scripts'][] = $filePath;
+
+                    $tags[] = $tag;
+
+                    $this->renderedFiles['scripts'][$filePath] = $tag;
                 }
             }
         }
 
         if ($isBuild && isset($options['preloadDynamicImports']) && true === $options['preloadDynamicImports']) {
             foreach ($entrypointsLookup->getJavascriptDynamicDependencies($entryName) as $filePath) {
-                if (false === \in_array($filePath, $this->renderedFiles['scripts'], true)) {
-                    $tags[] = $tagRenderer->createModulePreloadLinkTag(
+                if (!isset($this->renderedFiles['scripts'][$filePath])) {
+                    $tag = $tagRenderer->createModulePreloadLinkTag(
                         $this->completeURL($filePath, $useAbsoluteUrl),
                         ['integrity' => $entrypointsLookup->getFileHash($filePath)]
                     );
-                    $this->renderedFiles['scripts'][] = $filePath;
+
+                    $tags[] = $tag;
+
+                    $this->renderedFiles['scripts'][$filePath] = $tag;
                 }
             }
         }


### PR DESCRIPTION
Resolves #15 

This PR stores the tag object for each rendered script in the rendered scripts array so the `type` attribute can be checked in the `PreloadAssetsEventListener`.

If the `type` is `module`, we add the `crossorigin` attribute to the Link header.