### PR TITLE
Use modulepreload when adding Link header for module scripts

### DIFF
--- a/src/vite-bundle/src/EventListener/PreloadAssetsEventListener.php
+++ b/src/vite-bundle/src/EventListener/PreloadAssetsEventListener.php
@@ -11,8 +11,7 @@ use Symfony\Component\WebLink\Link;
 class PreloadAssetsEventListener implements EventSubscriberInterface
 {
     public function __construct(
-        private EntrypointRenderer $entrypointRenderer,
-        private string|bool $crossOriginAttribute
+        private EntrypointRenderer $entrypointRenderer
     ) {
     }
 
@@ -35,11 +34,8 @@ class PreloadAssetsEventListener implements EventSubscriberInterface
         $linkProvider = $request->attributes->get('_links');
 
         foreach ($this->entrypointRenderer->getRenderedScripts() as $href => $tag) {
-            $link = $this->createLink('preload', $href)->withAttribute('as', 'script');
-
-            if ('module' === $tag->getAttribute('type')) {
-                $link = $link->withAttribute('crossorigin', $this->crossOriginAttribute ?: 'anonymous');
-            }
+            $rel = $tag->isModule() || $tag->isModulePreload() ? 'modulepreload' : 'preload';
+            $link = $this->createLink($rel, $href)->withAttribute('as', 'script');
 
             $linkProvider = $linkProvider->withLink($link);
         }

--- a/src/vite-bundle/src/EventListener/PreloadAssetsEventListener.php
+++ b/src/vite-bundle/src/EventListener/PreloadAssetsEventListener.php
@@ -11,7 +11,8 @@ use Symfony\Component\WebLink\Link;
 class PreloadAssetsEventListener implements EventSubscriberInterface
 {
     public function __construct(
-        private EntrypointRenderer $entrypointRenderer
+        private EntrypointRenderer $entrypointRenderer,
+        private string|bool $crossOriginAttribute
     ) {
     }
 
@@ -37,6 +38,10 @@ class PreloadAssetsEventListener implements EventSubscriberInterface
             $rel = $tag->isModule() || $tag->isModulePreload() ? 'modulepreload' : 'preload';
             $link = $this->createLink($rel, $href)->withAttribute('as', 'script');
 
+            if (is_string($this->crossOriginAttribute)) {
+                $link = $link->withAttribute('crossorigin', $this->crossOriginAttribute);
+            }
+
             $linkProvider = $linkProvider->withLink($link);
         }
 
@@ -44,6 +49,11 @@ class PreloadAssetsEventListener implements EventSubscriberInterface
             $href = $tag->getAttribute('href');
             if (is_string($href)) {
                 $link = $this->createLink('preload', $href)->withAttribute('as', 'style');
+
+                if (is_string($this->crossOriginAttribute)) {
+                    $link = $link->withAttribute('crossorigin', $this->crossOriginAttribute);
+                }
+
                 $linkProvider = $linkProvider->withLink($link);
             }
         }

--- a/src/vite-bundle/src/Model/Tag.php
+++ b/src/vite-bundle/src/Model/Tag.php
@@ -43,6 +43,11 @@ class Tag
         return self::LINK_TAG === $this->tagName && 'modulepreload' === $this->getAttribute('rel');
     }
 
+    public function isModule(): bool
+    {
+        return self::SCRIPT_TAG === $this->tagName && 'module' === $this->getAttribute('type');
+    }
+
     /**
      * @return array<string, bool|string|null>
      */

--- a/src/vite-bundle/src/Resources/config/services.yaml
+++ b/src/vite-bundle/src/Resources/config/services.yaml
@@ -55,7 +55,6 @@ services:
         tags: ["kernel.event_subscriber"]
         arguments:
             - "@pentatrion_vite.entrypoint_renderer"
-            - "%pentatrion_vite.crossorigin%"
 
     pentatrion_vite.file_accessor:
         class: Pentatrion\ViteBundle\Service\FileAccessor

--- a/src/vite-bundle/src/Resources/config/services.yaml
+++ b/src/vite-bundle/src/Resources/config/services.yaml
@@ -55,6 +55,7 @@ services:
         tags: ["kernel.event_subscriber"]
         arguments:
             - "@pentatrion_vite.entrypoint_renderer"
+            - "%pentatrion_vite.crossorigin%"
 
     pentatrion_vite.file_accessor:
         class: Pentatrion\ViteBundle\Service\FileAccessor


### PR DESCRIPTION
This is a bit of a change to the work done in #16.

After reading https://web.dev/articles/modulepreload#why_doesnt_link_relpreload_work_for_modules I realised we don't need to add the crossorigin attribute, we can just use `modulepreload` instead of `preload` and let the browser take care of anything CORS related.

This also fixes an issue with dependency scripts with `rel=modulepreload` added here:

https://github.com/lhapaipai/symfony-vite-dev/blob/39b2bc83ee03f477dd4135e4fb7de7bf2e88fb3e/src/vite-bundle/src/Service/EntrypointRenderer.php#L260

These dependency scripts have `rel=modulepreload` but no `type=module`, so the work done in #16 wasn't adding the `crossorigin` attribute for these.

I didn't want to commit this directly to main, I'd like your review first please @lhapaipai 
