### PR TITLE
fix typo in error message when `outDir` is outside project root

### DIFF
--- a/src/vite-plugin-symfony/src/entrypoints/index.ts
+++ b/src/vite-plugin-symfony/src/entrypoints/index.ts
@@ -151,7 +151,7 @@ export default function symfonyEntrypoints(pluginOptions: VitePluginSymfonyEntry
           // buildDir is not a subdirectory of the vite project root -> potentially dangerous
           if (!isSubdirectory(viteConfig.root, buildDir) && viteConfig.build.emptyOutDir !== true) {
             logger.error(
-              `outDir ${buildDir} is not a subDirectory of your project root. To prevent recursively deleting files anywhere else set "build.outDir" to true in your vite.config.js to confirm that you did not accidentally specify a wrong directory location.`,
+              `outDir ${buildDir} is not a subDirectory of your project root. To prevent recursively deleting files anywhere else set "build.emptyOutDir" to true in your vite.config.js to confirm that you did not accidentally specify a wrong directory location.`,
             );
             process.exit(1);
           }


### PR DESCRIPTION
When `viteConfig.build.outDir` is configured to a path outside the project root a build will fail with an error message:

> outDir ${buildDir} is not a subDirectory of your project root. To prevent recursively deleting files anywhere else set "build.**outDir**" to true in your vite.config.js to confirm that you did not accidentally specify a wrong directory location.

i.e. the solution is said to be to set `build.outDir = true`.

But as can be seen just two lines above what is actually checked here is `viteConfig.build.emptyOutDir !== true`

https://github.com/lhapaipai/symfony-vite-dev/blob/5f1ac2e73ab548c49f05dedbc446e2a8d28048a8/src/vite-plugin-symfony/src/entrypoints/index.ts#L152

So the log message seems to be a typo and should instead suggest to set `build.emptyOutDir = true`.