### PR TITLE
Skip devServer lookup if proxy is defined

### DIFF
--- a/src/vite-bundle/src/Controller/ViteController.php
+++ b/src/vite-bundle/src/Controller/ViteController.php
@@ -2,8 +2,8 @@
 
 namespace Pentatrion\ViteBundle\Controller;
 
-use Pentatrion\ViteBundle\Service\EntrypointsLookupCollection;
 use Pentatrion\ViteBundle\Service\EntrypointsLookup;
+use Pentatrion\ViteBundle\Service\EntrypointsLookupCollection;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -26,7 +26,7 @@ class ViteController
         $entrypointsLookup = $this->entrypointsLookupCollection->getEntrypointsLookup($configName);
         $origin = $this->proxyOrigin ?? $this->resolveDevServer($entrypointsLookup);
         $base = $entrypointsLookup->getBase();
-        
+
         $response = $this->httpClient->request(
             'GET',
             $origin.$base.$path

--- a/src/vite-bundle/src/Controller/ViteController.php
+++ b/src/vite-bundle/src/Controller/ViteController.php
@@ -3,6 +3,7 @@
 namespace Pentatrion\ViteBundle\Controller;
 
 use Pentatrion\ViteBundle\Service\EntrypointsLookupCollection;
+use Pentatrion\ViteBundle\Service\EntrypointsLookup;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -23,16 +24,9 @@ class ViteController
         }
 
         $entrypointsLookup = $this->entrypointsLookupCollection->getEntrypointsLookup($configName);
-
-        $viteDevServer = $entrypointsLookup->getViteServer();
+        $origin = $this->proxyOrigin ?? $this->resolveDevServer($entrypointsLookup);
         $base = $entrypointsLookup->getBase();
-
-        if (is_null($viteDevServer)) {
-            throw new \Exception('Vite dev server not available');
-        }
-
-        $origin = $this->proxyOrigin ?? $viteDevServer;
-
+        
         $response = $this->httpClient->request(
             'GET',
             $origin.$base.$path
@@ -43,5 +37,16 @@ class ViteController
         $headers = $response->getHeaders();
 
         return new Response($content, $statusCode, $headers);
+    }
+
+    private function resolveDevServer(EntrypointsLookup $entrypointsLookup): string
+    {
+        $viteDevServer = $entrypointsLookup->getViteServer();
+
+        if (is_null($viteDevServer)) {
+            throw new \Exception('Vite dev server not available');
+        }
+
+        return $viteDevServer;
     }
 }


### PR DESCRIPTION
There is no need to resolve the dev server if a proxy is defined, because we would not use that value.

The check in itself is useless if we use a proxy as the dev server lookup may resolve to null even though it is perfectly accessible via proxy.