### PR TITLE
Use proxy_origin in Debugger if configured

### DIFF
--- a/src/vite-bundle/src/Resources/config/services.yaml
+++ b/src/vite-bundle/src/Resources/config/services.yaml
@@ -52,6 +52,7 @@ services:
             - "%pentatrion_vite.configs%"
             - "@http_client"
             - "@pentatrion_vite.entrypoints_lookup_collection"
+            - "%pentatrion_vite.proxy_origin%"
 
     Pentatrion\ViteBundle\Controller\ViteController:
         tags: ["controller.service_arguments"]

--- a/src/vite-bundle/src/Service/Debug.php
+++ b/src/vite-bundle/src/Service/Debug.php
@@ -17,6 +17,7 @@ class Debug
         private array $configs,
         private HttpClientInterface $httpClient,
         private EntrypointsLookupCollection $entrypointsLookupCollection,
+        private ?string $proxyOrigin,
     ) {
     }
 
@@ -38,7 +39,7 @@ class Debug
         $viteServerRequests = array_map(
             function ($configName) {
                 $entrypointsLookup = $this->entrypointsLookupCollection->getEntrypointsLookup($configName);
-                $viteServer = $entrypointsLookup->getViteServer();
+                $viteServer = $this->proxyOrigin ?? $entrypointsLookup->getViteServer();
 
                 return [
                     'configName' => $configName,

--- a/src/vite-bundle/tests/Service/DebugTest.php
+++ b/src/vite-bundle/tests/Service/DebugTest.php
@@ -157,7 +157,8 @@ class DebugTest extends TestCase
         $debug = new Debug(
             ['_default' => self::createEmptyConfig()],
             $mockHttpClient,
-            $mockEntrypointsLookupCollection
+            $mockEntrypointsLookupCollection,
+            null,
         );
 
         $configRunning = $debug->getViteCompleteConfigs();
@@ -177,7 +178,8 @@ class DebugTest extends TestCase
         $debug = new Debug(
             ['_default' => self::createEmptyConfig()],
             new MockHttpClient(),
-            $mockEntrypointsLookupCollection
+            $mockEntrypointsLookupCollection,
+            null,
         );
 
         $config = $debug->getViteCompleteConfigs();


### PR DESCRIPTION
Hi @lhapaipai,

Sorry I missed this in the PR review, but the Debug class doesn't use the `proxy_origin` if it's configured like `ViteController` does. This causes a "Your Vite Dev server is not running" error message.