### PR TITLE
[vite-bundle] Fix: consider the case where the response from the vite server is encode

### DIFF
--- a/src/vite-bundle/src/Controller/ViteController.php
+++ b/src/vite-bundle/src/Controller/ViteController.php
@@ -29,7 +29,8 @@ class ViteController
 
         $response = $this->httpClient->request(
             'GET',
-            $origin.$base.$path
+            $origin.$base.$path,
+            ['headers' => ['Accept-Encoding' => '']],
         );
 
         $content = $response->getContent();


### PR DESCRIPTION
When the response from the Vite server contains `content-encoding` header, `ViteController` includes `content-encoding` in the response header and forwards it, even though `symfony/http-client` implicitly decodes the content. This causes a problem in which the client cannot decode the response from `ViteController`.

We can solve this problem by disabling implicit decoding by specifying an empty string in the `Accept-Encoding` header when making a request to the Vite server.

> refs: https://github.com/symfony/symfony/issues/34238

Thanks.