### PR TITLE
Add origin to internal tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ node_modules
 
 /.vscode/settings.json
 /.vscode/launch.json
+/.idea
 
 # Local Netlify folder
 .netlify

--- a/src/vite-bundle/src/Model/Tag.php
+++ b/src/vite-bundle/src/Model/Tag.php
@@ -19,6 +19,7 @@ class Tag
         private string $content = '',
         private string $origin = '',
         string $preloadOption = 'link-tag',
+        private bool $internal = false,
     ) {
         if (self::LINK_TAG === $tagName && isset($attributes['rel'])) {
             if (in_array($attributes['rel'], ['modulepreload', 'preload']) && 'link-tag' !== $preloadOption) {
@@ -148,7 +149,7 @@ class Tag
 
     public function isInternal(): bool
     {
-        return '_internal' === $this->origin;
+        return $this->internal;
     }
 
     public function isRenderAsTag(): bool

--- a/src/vite-bundle/src/Service/EntrypointRenderer.php
+++ b/src/vite-bundle/src/Service/EntrypointRenderer.php
@@ -133,7 +133,7 @@ class EntrypointRenderer implements ResetInterface
         if (!is_null($viteServer)) {
             // vite server is active
             if (!isset($this->returnedViteClients[$configName])) {
-                $tags[] = $tagRenderer->createViteClientScript($viteServer.$base.'@vite/client');
+                $tags[] = $tagRenderer->createViteClientScript($viteServer.$base.'@vite/client', $entryName);
 
                 $this->returnedViteClients[$configName] = true;
             }
@@ -165,7 +165,8 @@ class EntrypointRenderer implements ResetInterface
                         'id' => 'vite-legacy-polyfill',
                     ],
                     '',
-                    '_internal'
+                    $entryName,
+                    true,
                 );
             }
 

--- a/src/vite-bundle/src/Service/TagRenderer.php
+++ b/src/vite-bundle/src/Service/TagRenderer.php
@@ -23,14 +23,16 @@ class TagRenderer
     ) {
     }
 
-    public function createViteClientScript(string $src): Tag
+    public function createViteClientScript(string $src, string $entryName = ''): Tag
     {
         return $this->createInternalScriptTag(
             [
                 'type' => 'module',
                 'src' => $src,
                 'crossorigin' => true,
-            ]
+            ],
+            '',
+            $entryName
         );
     }
 
@@ -67,21 +69,22 @@ class TagRenderer
     }
 
     /** @param array<string, bool|string|null> $attributes */
-    public function createInternalScriptTag(array $attributes = [], string $content = ''): Tag
+    public function createInternalScriptTag(array $attributes = [], string $content = '', string $origin = ''): Tag
     {
         $tag = new Tag(
             Tag::SCRIPT_TAG,
             $attributes,
             $content,
-            '_internal',
-            $this->preload
+            $origin,
+            $this->preload,
+            true,
         );
 
         return $tag;
     }
 
     /** @param array<string, bool|string|null> $attributes */
-    public function createScriptTag(array $attributes = [], string $content = '', string $origin = ''): Tag
+    public function createScriptTag(array $attributes = [], string $content = '', string $origin = '', bool $internal = false): Tag
     {
         $tag = new Tag(
             Tag::SCRIPT_TAG,
@@ -92,7 +95,8 @@ class TagRenderer
             ),
             $content,
             $origin,
-            $this->preload
+            $this->preload,
+            $internal
         );
 
         return $tag;

--- a/src/vite-bundle/tests/Service/TagRendererTest.php
+++ b/src/vite-bundle/tests/Service/TagRendererTest.php
@@ -169,6 +169,16 @@ class TagRendererTest extends TestCase
             '<script type="module" src="http://127.0.0.1:5173/build/@vite/client" crossorigin></script>',
             $tagRenderer->generateTag($tag)
         );
+        $this->assertTrue($tag->isInternal());
+        $this->assertEquals('', $tag->getOrigin());
+
+        $tag = $tagRenderer->createViteClientScript('http://127.0.0.1:5173/build/@vite/client', 'app-foo');
+        $this->assertEquals(
+            '<script type="module" src="http://127.0.0.1:5173/build/@vite/client" crossorigin></script>',
+            $tagRenderer->generateTag($tag)
+        );
+        $this->assertTrue($tag->isInternal());
+        $this->assertEquals('app-foo', $tag->getOrigin());
 
         $tag = $tagRenderer->createReactRefreshScript('http://127.0.0.1:5173');
         $this->assertEquals(


### PR DESCRIPTION
I noticed that custom attribtues aren't applied to the Vite client script. This causes problems if you need to pass a nonce for example.