### PR TITLE
Change dependency to the non-internal Extension class

### DIFF
--- a/src/vite-bundle/src/DependencyInjection/PentatrionViteExtension.php
+++ b/src/vite-bundle/src/DependencyInjection/PentatrionViteExtension.php
@@ -10,7 +10,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\WebLink\EventListener\AddLinkHeaderListener;
 
 /**


### PR DESCRIPTION
The `Symfony\Component\HttpKernel\DependencyInjection\Extension` class is considered internal since Symfony 7.1, to be deprecated in 8.1; 
We should use `Symfony\Component\DependencyInjection\Extension\Extension` instead.
