### PR TITLE
fix: Type error

### DIFF
--- a/src/vite-bundle/src/Service/Debug.php
+++ b/src/vite-bundle/src/Service/Debug.php
@@ -89,7 +89,9 @@ class Debug
         /** @var array<string, mixed> $value */
         foreach ($config as $key => $value) {
             if (in_array($key, $groupKeys)) {
-                ksort($value);
+                if(\is_array($value)) {
+                    ksort($value);
+                }
                 $output[$key] = $value;
             } else {
                 $output['principal'][$key] = $value;

--- a/src/vite-bundle/src/Service/Debug.php
+++ b/src/vite-bundle/src/Service/Debug.php
@@ -89,7 +89,7 @@ class Debug
         /** @var array<string, mixed> $value */
         foreach ($config as $key => $value) {
             if (in_array($key, $groupKeys)) {
-                if(\is_array($value)) {
+                if (\is_array($value)) {
                     ksort($value);
                 }
                 $output[$key] = $value;


### PR DESCRIPTION
Fixes the error:


> `ksort(): Argument #1 ($array) must be of type array, false given`

The key `esbuild` in the array can have a false value