### PR TITLE
Add support for Symfony 8

### DIFF
--- a/src/vite-bundle/composer.json
+++ b/src/vite-bundle/composer.json
@@ -17,13 +17,13 @@
     ],
     "require": {
         "php": "^8.0",
-        "symfony/asset": "^4.4 || ^5.0 || ^6.0 || ^7.0",
-        "symfony/config": "^4.4 || ^5.0 || ^6.0 || ^7.0",
-        "symfony/dependency-injection": "^4.4 || ^5.0 || ^6.0 || ^7.0",
-        "symfony/http-client": "^4.4 || ^5.0 || ^6.0 || ^7.0",
-        "symfony/http-kernel": "^4.4 || ^5.0 || ^6.0 || ^7.0",
-        "symfony/framework-bundle": "^4.4 || ^5.0 || ^6.0 || ^7.0",
-        "symfony/twig-bundle": "^4.4 || ^5.0 || ^6.0 || ^7.0"
+        "symfony/asset": "^4.4 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/config": "^4.4 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/dependency-injection": "^4.4 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/http-client": "^4.4 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/http-kernel": "^4.4 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/framework-bundle": "^4.4 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/twig-bundle": "^4.4 || ^5.0 || ^6.0 || ^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {
@@ -40,8 +40,8 @@
         "phpstan/phpstan": "^1.8",
         "phpstan/phpstan-symfony": "^1.3",
         "phpunit/phpunit": "^9.5",
-        "symfony/phpunit-bridge": "^4.4 || ^5.0 || ^6.0 || ^7.0",
-        "symfony/web-link": "^4.4 || ^5.0 || ^6.0 || ^7.0"
+        "symfony/phpunit-bridge": "^4.4 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/web-link": "^4.4 || ^5.0 || ^6.0 || ^7.0 || ^8.0"
     },
     "scripts": {
         "cs-fix": "php8.3 vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php",


### PR DESCRIPTION
I considered dropping 4.x and 5.x and increasing the requirement for 6.x to 6.4, but decided it wasn't necessary. I didn't add Symfony 8 playground either, because we need to add PHP 8.4 support to the CI first.