### PR TITLE
Stimulus doc: Fix incorrect variable name

### DIFF
--- a/docs/src/stimulus/installation.md
+++ b/docs/src/stimulus/installation.md
@@ -148,7 +148,7 @@ const app = startStimulusApp();
 // some logic
 
 + if (import.meta.hot) {
-+   window.$$stimulusApp$$ = stimulusApp;
++   window.$$stimulusApp$$ = app;
 + }
 ```
 :::


### PR DESCRIPTION
The example uses the `app` variable name instead of `stimulusApp`.