### PR TITLE
chore: Remove `predev` script in vite-plugin-symfony.

### DIFF
--- a/src/vite-plugin-symfony/package.json
+++ b/src/vite-plugin-symfony/package.json
@@ -58,7 +58,6 @@
     "url": "https://github.com/lhapaipai/vite-plugin-symfony.git"
   },
   "scripts": {
-    "predev": "tsx ./scripts/pre-dev.ts",
     "dev": "tsup --watch",
     "build": "tsup",
     "test": "vitest",


### PR DESCRIPTION
Remove useless `predev` script.