### PR TITLE
feat (`vite-plugin-symfony`) : Support use `modernPolyfills` option in `@vitejs/plugin-legacy`.

### DIFF
--- a/src/vite-plugin-symfony/src/entrypoints/entryPointsHelper.ts
+++ b/src/vite-plugin-symfony/src/entrypoints/entryPointsHelper.ts
@@ -64,11 +64,31 @@ export const getBuildEntryPoints = (generatedFiles: GeneratedFiles, viteConfig: 
       hasLegacyEntryPoint ? `${entryName}-legacy` : false,
     );
   }
+ 
+  /**
+   * legacy polyfills target browsers that don't support ESM at all.
+   * added as <script nomodule> tags for legacy browsers.
+   * @see https://github.com/vitejs/vite/tree/main/packages/plugin-legacy#polyfills 
+   * */
+  const polyfills = getOutputPath("vite/legacy-polyfills-legacy")
 
-  if (hasLegacyEntryPoint && getOutputPath("vite/legacy-polyfills")) {
-    const fileInfos = generatedFiles[getOutputPath("vite/legacy-polyfills")!] ?? null;
+  if (hasLegacyEntryPoint && polyfills) {
+    const fileInfos = generatedFiles[polyfills];
     if (fileInfos) {
       entryPoints["polyfills-legacy"] = resolveBuildEntrypoint(fileInfos, generatedFiles, viteConfig, false);
+    }
+  }
+
+  /** 
+   * modern polyfills target browsers that support ESM but lack certain widely-available features.
+   * added as <script type="module"> tags in HTML.
+   * @see https://github.com/vitejs/vite/tree/main/packages/plugin-legacy#modernpolyfills */
+  const modernPolyfills = getOutputPath("vite/legacy-polyfills")
+
+  if (modernPolyfills) {
+    const fileInfos = generatedFiles[modernPolyfills];
+    if(fileInfos) {
+      entryPoints["polyfills"] = resolveBuildEntrypoint(fileInfos, generatedFiles, viteConfig, false);
     }
   }
 

--- a/src/vite-plugin-symfony/src/entrypoints/index.test.ts
+++ b/src/vite-plugin-symfony/src/entrypoints/index.test.ts
@@ -18,6 +18,7 @@ import {
   circular1Js,
   circular2Js,
   viteUserConfigNoRoot,
+  modernPolyfills,
 } from "~tests/mocks";
 import { VitePluginSymfonyEntrypointsOptions } from "~/types";
 import { createLogger, Logger } from "vite";
@@ -342,6 +343,71 @@ describe("vitePluginSymfonyEntrypoints", () => {
               css: [],
               dynamic: [],
               js: ["/build/assets/polyfills-legacy-40963d34.js"],
+              legacy: false,
+              preload: [],
+            },
+          },
+          legacy: true,
+          metadatas: {},
+          version: ["test"],
+          viteServer: null,
+        },
+        null,
+        2,
+      ),
+      type: "asset",
+    });
+  });
+
+  it("generate correct legacy build entrypoints with modern polyfills", ({ expect }) => {
+    const legacyPluginInstance = plugin({ debug: true }) as any;
+    legacyPluginInstance.emitFile = vi.fn();
+    legacyPluginInstance.configResolved({
+      ...viteBaseConfig,
+      build: {
+        rollupOptions: {
+          input: {
+            welcome: "./assets/page/welcome/index.js",
+          },
+          output: [{ format: "system" }, { format: "es" }],
+        },
+      },
+    });
+
+    legacyPluginInstance.generateBundle({ format: "system" }, createBundleObject([welcomeLegacyJs, legacyPolyfills]));
+    legacyPluginInstance.generateBundle({ format: "es" }, createBundleObject([welcomeJs, modernPolyfills]));
+
+    expect(legacyPluginInstance.emitFile).toHaveBeenCalledWith({
+      fileName: ".vite/entrypoints.json",
+      source: JSON.stringify(
+        {
+          base: "/build/",
+          entryPoints: {
+            "welcome-legacy": {
+              css: [],
+              dynamic: [],
+              js: ["/build/assets/welcome-legacy-64979d13.js"],
+              legacy: false,
+              preload: [],
+            },
+            welcome: {
+              css: [],
+              dynamic: [],
+              js: ["/build/assets/welcome-1e67239d.js"],
+              legacy: "welcome-legacy",
+              preload: [],
+            },
+            "polyfills-legacy": {
+              css: [],
+              dynamic: [],
+              js: ["/build/assets/polyfills-legacy-40963d34.js"],
+              legacy: false,
+              preload: [],
+            },
+            "polyfills": {
+              css: [],
+              dynamic: [],
+              js: ["/build/assets/polyfills-Cj9hW7C2.js"],
               legacy: false,
               preload: [],
             },

--- a/src/vite-plugin-symfony/src/entrypoints/utils.test.ts
+++ b/src/vite-plugin-symfony/src/entrypoints/utils.test.ts
@@ -419,6 +419,34 @@ describe("getInputRelPath", () => {
       ),
     ).toBe("assets/page/welcome/index-legacy.js");
   });
+
+  it("generate correct polyfills path", () => {
+    expect(
+      getInputRelPath(
+        {
+          type: "chunk",
+          facadeModuleId: "\0vite/legacy-polyfills",
+          name: "polyfills",
+          fileName: "polyfills-legacy.js"
+        } as OutputChunk,
+        { format: "system" } as NormalizedOutputOptions,
+        viteBaseConfig
+      )
+    ).toBe("vite/legacy-polyfills-legacy")
+
+    expect(
+      getInputRelPath(
+        {
+          type: "chunk",
+          facadeModuleId: "\0vite/legacy-polyfills",
+          name: "polyfills",
+          fileName: "polyfills.js"
+        } as OutputChunk,
+        { format: "system" } as NormalizedOutputOptions,
+        viteBaseConfig
+      )
+    ).toBe("vite/legacy-polyfills")
+  })
 });
 
 describe("isAncestorDir", () => {

--- a/src/vite-plugin-symfony/src/entrypoints/utils.ts
+++ b/src/vite-plugin-symfony/src/entrypoints/utils.ts
@@ -95,7 +95,7 @@ const cssModuleRE = new RegExp(`\\.module${CSS_LANGS_RE.source}`);
 const commonjsProxyRE = /\?commonjs-proxy/;
 const isCSSRequest = (request: string) => CSS_LANGS_RE.test(request);
 
-const polyfillId = "\0vite/legacy-polyfills";
+export const polyfillId = "\0vite/legacy-polyfills";
 
 export function resolveDevServerUrl(
   address: AddressInfo,
@@ -242,7 +242,15 @@ export const getInputRelPath = (
   }
 
   if ([polyfillId].indexOf(chunk.facadeModuleId) !== -1) {
-    return chunk.facadeModuleId.replace(/\0/g, "");
+    // modern polyfill chunk and legacy polyfill chunk uses same polyfillId
+    const baseInputRelPath =  chunk.facadeModuleId.replace(/\0/g, "")
+    if (options.format === 'system' && chunk.fileName.includes('-legacy')) {
+      // legacy polyfill 
+      return `${baseInputRelPath}-legacy`;  
+    } else {
+      // modern polyfill
+      return baseInputRelPath;  
+    }  
   }
 
   let inputRelPath = normalizePath(path.relative(config.root, chunk.facadeModuleId));

--- a/src/vite-plugin-symfony/tests/mocks.ts
+++ b/src/vite-plugin-symfony/tests/mocks.ts
@@ -124,6 +124,21 @@ export const legacyPolyfills = {
   code: 'console.log("welcome.js !");\n',
 } as unknown as OutputChunk & { viteMetadata: ChunkMetadata };
 
+export const modernPolyfills = {
+  dynamicImports: [],
+  type: "chunk",
+  facadeModuleId: "\0vite/legacy-polyfills",
+  fileName: "assets/polyfills-Cj9hW7C2.js",
+  name: "polyfills",
+  isEntry: true,
+  imports: [],
+  viteMetadata: {
+    importedCss: new Set(),
+    importedAssets: new Set(),
+  },
+  code: 'console.log("welcome.js !");\n',
+} as unknown as OutputChunk & { viteMetadata: ChunkMetadata };
+
 export const pageAssets = {
   dynamicImports: [],
   type: "chunk",


### PR DESCRIPTION
### 1. What does this PR do?
Support use `modernPolyfills` option in `@vitejs/plugin-legacy`.

### 2. Why is this change necessary?
The primary purpose of the `modernPolyfills` option in `@vitejs/plugin-legacy` is to provide progressive enhancement for "nearly-modern" browsers. These are browsers that support native ES modules (ESM) but may lack certain newer features, requiring polyfills to ensure full compatibility.

However, when `modernPolyfills` is configured in the current version of `vite-plugin-symfony`, it causes a build error when generating the polyfill bundle. This, in turn, disrupts the correct generation of the standard legacy polyfills.

### 3. Before & After
**vite.config.js**

``` js
// playground/legacy/vite.config.js
// ...
  legacy({
      targets: ["defaults", "not IE 11"],
      modernPolyfills: ["es.promise.with-resolvers"], // added modernPolyfills option
    }),
// ...
```


**before**

``` js
// manifest.json
{
  "vite/legacy-polyfills": {
    "file": "assets/polyfills-Cj9hW7C2.js", // correct modern polyfill file.
    "name": "polyfills",
    "src": "vite/legacy-polyfills",
    "isEntry": true
  },
  "vite/legacy-polyfills-legacy": {
    "file": "assets/polyfills-legacy-DaRYkj8E.js", // correct legacy polyfill file.
    "name": "polyfills",
    "src": "vite/legacy-polyfills-legacy",
    "isEntry": true
  }
}
```

``` js
// entrypoints.json
{
  "polyfills-legacy": {
      "css": [],
      "dynamic": [],
      "js": [
        "/build/assets/polyfills-Cj9hW7C2.js" // wrong polyfill file, this is modern polyfill file. missed legacy polyfill file.
      ],
      "legacy": false,
      "preload": []
    }
}
```

**after**

``` js
// same manifest.json
// manifest.json
{
  "vite/legacy-polyfills": {
    "file": "assets/polyfills-Cj9hW7C2.js",
    "name": "polyfills",
    "src": "vite/legacy-polyfills",
    "isEntry": true
  },
  "vite/legacy-polyfills-legacy": {
    "file": "assets/polyfills-legacy-DaRYkj8E.js",
    "name": "polyfills",
    "src": "vite/legacy-polyfills-legacy",
    "isEntry": true
  }
}
```

``` js
// entrypoints.json
{
  "polyfills-legacy": {
      "css": [],
      "dynamic": [],
      "js": [
        "/build/assets/polyfills-legacy-DaRYkj8E.js" // use legacy polyfill file.
      ],
      "legacy": false,
      "preload": []
    },
    "polyfills": { // added modern polyfill file.
      "css": [],
      "dynamic": [],
      "js": [
        "/build/assets/polyfills-Cj9hW7C2.js"
      ],
      "legacy": false,
      "preload": []
    }
}
```