### PR TITLE
Fix renderScripts/renderLinks returning string despite the toString option being set to false

### DIFF
--- a/src/vite-bundle/src/Service/EntrypointRenderer.php
+++ b/src/vite-bundle/src/Service/EntrypointRenderer.php
@@ -120,7 +120,7 @@ class EntrypointRenderer implements ResetInterface
         $tagRenderer = $this->getTagRenderer($configName);
 
         if (!$entrypointsLookup->hasFile()) {
-            return '';
+            return $toString ? '' : [];
         }
 
         $useAbsoluteUrl = $this->shouldUseAbsoluteURL($options, $configName);
@@ -254,7 +254,7 @@ class EntrypointRenderer implements ResetInterface
         $tagRenderer = $this->getTagRenderer($configName);
 
         if (!$entrypointsLookup->hasFile()) {
-            return '';
+            return $toString ? '' : [];
         }
 
         $useAbsoluteUrl = $this->shouldUseAbsoluteURL($options, $configName);


### PR DESCRIPTION
I've kept wondering why occasionally I got an exception telling me that this function returns string, but it actually does return string when nothing is found :) 